### PR TITLE
Index deletion - processing model updates

### DIFF
--- a/src/main/java/redis/clients/johm/JOhm.java
+++ b/src/main/java/redis/clients/johm/JOhm.java
@@ -153,6 +153,9 @@ public final class JOhm {
 
     @SuppressWarnings("unchecked")
     public static <T> T save(final Object model, boolean saveChildren) {
+        if (!isNew(model)) {
+            delete(model.getClass(), JOhmUtils.getId(model));
+        }
         final Nest nest = initIfNeeded(model);
 
         final Map<String, String> hashedObject = new HashMap<String, String>();
@@ -290,7 +293,8 @@ public final class JOhm {
                             fieldValue = JOhmUtils.getId(fieldValue);
                         }
                         if (!JOhmUtils.isNullOrEmpty(fieldValue)) {
-                            nest.cat(field.getName()).cat(fieldValue).del();
+                            nest.cat(field.getName()).cat(fieldValue).srem(
+                                    String.valueOf(id));
                         }
                     }
                 }

--- a/src/main/java/redis/clients/johm/collections/RedisArray.java
+++ b/src/main/java/redis/clients/johm/collections/RedisArray.java
@@ -67,7 +67,9 @@ public class RedisArray<T> {
         if (element != null) {
             success = nest.cat(JOhmUtils.getId(owner)).cat(field.getName())
                     .rpush(JOhmUtils.getId(element).toString()) > 0;
-            indexValue(element);
+            if (isIndexed) {
+                indexValue(element);
+            }
         }
         return success;
     }

--- a/src/test/java/redis/clients/johm/BasicPersistanceTest.java
+++ b/src/test/java/redis/clients/johm/BasicPersistanceTest.java
@@ -60,7 +60,7 @@ public class BasicPersistanceTest extends JOhmTestBase {
         assertEquals(item2.getId(), saved[2].getId());
         assertEquals(item2.getName(), saved[2].getName());
 
-        assertTrue(JOhm.delete(User.class, savedUser.getId(), true));
+        assertTrue(JOhm.delete(User.class, savedUser.getId(), true, true));
         assertTrue(JOhm.delete(Item.class, item0.getId()));
         assertTrue(JOhm.delete(Item.class, item1.getId()));
         assertTrue(JOhm.delete(Item.class, item2.getId()));

--- a/src/test/java/redis/clients/johm/SearchTest.java
+++ b/src/test/java/redis/clients/johm/SearchTest.java
@@ -272,9 +272,9 @@ public class SearchTest extends JOhmTestBase {
         assertNotNull(JOhm.get(User.class, id));
 
         List<User> users = JOhm.find(User.class, "age", 88);
-        assertEquals(1, users.size());
+        assertEquals(0, users.size()); // index already updated
         users = JOhm.find(User.class, "age", 77);
-        assertEquals(1, users.size());
+        assertEquals(0, users.size()); // index already updated
         users = JOhm.find(User.class, "age", 66);
         assertEquals(1, users.size());
 

--- a/src/test/java/redis/clients/johm/SearchTest.java
+++ b/src/test/java/redis/clients/johm/SearchTest.java
@@ -254,4 +254,39 @@ public class SearchTest extends JOhmTestBase {
         assertEquals(user1.getId(), users.get(0).getId());
         assertEquals(user2.getId(), users.get(1).getId());
     }
+
+    @Test
+    public void cannotSearchAfterDeletingIndexes() {
+        User user = new User();
+        user.setAge(88);
+        JOhm.save(user);
+
+        user.setAge(77); // younger
+        JOhm.save(user);
+
+        user.setAge(66); // younger still
+        JOhm.save(user);
+
+        int id = user.getId();
+
+        assertNotNull(JOhm.get(User.class, id));
+
+        List<User> users = JOhm.find(User.class, "age", 88);
+        assertEquals(1, users.size());
+        users = JOhm.find(User.class, "age", 77);
+        assertEquals(1, users.size());
+        users = JOhm.find(User.class, "age", 66);
+        assertEquals(1, users.size());
+
+        JOhm.delete(User.class, id);
+
+        users = JOhm.find(User.class, "age", 88);
+        assertEquals(0, users.size());
+        users = JOhm.find(User.class, "age", 77);
+        assertEquals(0, users.size());
+        users = JOhm.find(User.class, "age", 66);
+        assertEquals(0, users.size());
+
+        assertNull(JOhm.get(User.class, id));
+    }
 }


### PR DESCRIPTION
Per our discussion, now handling the update scenario during model-save such that deletion is cleaner and consistent.
